### PR TITLE
Add recent change in mw query result

### DIFF
--- a/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 public class MwQueryResult extends BaseModel implements PostProcessingTypeAdapter.PostProcessable {
     @SuppressWarnings("unused") @Nullable private List<MwQueryPage> pages;
+    private List<RecentChange> recentchanges;
     @SuppressWarnings("unused") @Nullable private List<Redirect> redirects;
     @SuppressWarnings("unused") @Nullable private List<ConvertedTitle> converted;
     @SuppressWarnings("unused") @SerializedName("userinfo") private UserInfo userInfo;
@@ -85,6 +86,10 @@ public class MwQueryResult extends BaseModel implements PostProcessingTypeAdapte
             }
         }
         return captchaId;
+    }
+
+    public List<RecentChange> getRecentchanges() {
+        return recentchanges;
     }
 
     @Nullable public ListUserResponse getUserResponse(@NonNull String userName) {

--- a/src/main/java/org/wikipedia/dataclient/mwapi/RecentChange.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/RecentChange.java
@@ -1,0 +1,22 @@
+package org.wikipedia.dataclient.mwapi;
+
+import com.google.gson.annotations.SerializedName;
+
+public class RecentChange {
+    private String type;
+    private String title;
+    @SerializedName("old_revid")
+    private String oldRevisionId;
+
+    public String getType() {
+        return type;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getOldRevisionId() {
+        return oldRevisionId;
+    }
+}


### PR DESCRIPTION
Commons app recently added a feature to peer review recent changes (#2602). 

The `MwQueryResult` in the library doesn't contain `recentchanges` object. This PR adds the model class. 

https://github.com/commons-app/apps-android-commons/blob/master/app/src/main/java/fr/free/nrw/commons/mwapi/model/MwQueryResult.java

