### PR TITLE
Add getter for categories in ExtMetaData

### DIFF
--- a/src/main/java/org/wikipedia/gallery/ExtMetadata.java
+++ b/src/main/java/org/wikipedia/gallery/ExtMetadata.java
@@ -13,6 +13,8 @@ public class ExtMetadata {
     @SuppressWarnings("unused") @SerializedName("CommonsMetadataExtension") @Nullable private Values commonsMetadataExtension;
     @SuppressWarnings("unused") @SerializedName("Categories") @Nullable private Values categories;
     @SuppressWarnings("unused") @SerializedName("Assessments") @Nullable private Values assessments;
+    @SuppressWarnings("unused") @SerializedName("GPSLatitude") @Nullable private Values gpsLatitude;
+    @SuppressWarnings("unused") @SerializedName("GPSLongitude") @Nullable private Values gpsLongitude;
     @SuppressWarnings("unused") @SerializedName("ImageDescription") @Nullable private Values imageDescription;
     @SuppressWarnings("unused") @SerializedName("DateTimeOriginal") @Nullable private Values dateTimeOriginal;
     @SuppressWarnings("unused") @SerializedName("Artist") @Nullable private Values artist;
@@ -63,9 +65,19 @@ public class ExtMetadata {
         return artist != null ? artist : new Values();
     }
 
-    @Nullable
+    @NonNull
     public Values categories() {
         return categories != null ? categories : new Values();
+    }
+
+    @NonNull
+    public Values gpsLatitude() {
+        return gpsLatitude != null ? gpsLatitude : new Values();
+    }
+
+    @NonNull
+    public Values gpsLongitude() {
+        return gpsLongitude != null ? gpsLongitude : new Values();
     }
 
     public class Values {

--- a/src/main/java/org/wikipedia/gallery/ExtMetadata.java
+++ b/src/main/java/org/wikipedia/gallery/ExtMetadata.java
@@ -63,6 +63,11 @@ public class ExtMetadata {
         return artist != null ? artist : new Values();
     }
 
+    @Nullable
+    public Values categories() {
+        return categories != null ? categories : new Values();
+    }
+
     public class Values {
         @SuppressWarnings("unused,NullableProblems") @Nullable private String value;
         @SuppressWarnings("unused,NullableProblems") @Nullable private String source;


### PR DESCRIPTION
GPS and category information is required while constructing the `Media` object in commons. 