### PR TITLE
Add allimages prop in MwQueryPage

### DIFF
--- a/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryPage.java
@@ -11,6 +11,7 @@ import org.wikipedia.gallery.VideoInfo;
 import org.wikipedia.model.BaseModel;
 import org.wikipedia.page.Namespace;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,6 +33,7 @@ public class MwQueryPage extends BaseModel {
     @SuppressWarnings("unused") @Nullable private Thumbnail thumbnail;
     @SuppressWarnings("unused") @Nullable private String description;
     @SuppressWarnings("unused") @SerializedName("descriptionsource") @Nullable private String descriptionSource;
+    @SuppressWarnings("unused") @SerializedName("allimages") @Nullable private List<ImageInfo> allImages;
     @SuppressWarnings("unused") @SerializedName("imageinfo") @Nullable private List<ImageInfo> imageInfo;
     @SuppressWarnings("unused") @SerializedName("videoinfo") @Nullable private List<VideoInfo> videoInfo;
     @Nullable private String redirectFrom;
@@ -98,6 +100,11 @@ public class MwQueryPage extends BaseModel {
     @Nullable
     public String descriptionSource() {
         return descriptionSource;
+    }
+
+    @NonNull
+    public List<ImageInfo> allImages() {
+        return allImages == null ? new ArrayList<>() : allImages;
     }
 
     @Nullable public ImageInfo imageInfo() {


### PR DESCRIPTION
Commons app uses [allimages](https://www.mediawiki.org/wiki/API:Allimages) API to check if a file exists by searching for files with the same SHA. 

Adding, `allimages` property in `MwQueryPage` to parse the result. Not sure if the duplication can be avoided or not. 