### PR TITLE
Make required properties available in ExtMetaData

### DIFF
--- a/src/main/java/org/wikipedia/gallery/ExtMetadata.java
+++ b/src/main/java/org/wikipedia/gallery/ExtMetadata.java
@@ -14,6 +14,12 @@ public class ExtMetadata {
     @SerializedName("CommonsMetadataExtension") @Nullable private Values commonsMetadataExtension;
     @SerializedName("Categories") @Nullable private Values categories;
     @SerializedName("Assessments") @Nullable private Values assessments;
+    @SerializedName("GPSLatitude")
+    @Nullable
+    private Values gpsLatitude;
+    @SerializedName("GPSLongitude")
+    @Nullable
+    private Values gpsLongitude;
     @SerializedName("ImageDescription") @Nullable private Values imageDescription;
     @SerializedName("DateTimeOriginal") @Nullable private Values dateTimeOriginal;
     @SerializedName("Artist") @Nullable private Values artist;
@@ -56,12 +62,31 @@ public class ExtMetadata {
         return StringUtils.defaultString(usageTerms == null ? null : usageTerms.value());
     }
 
-    @NonNull public String dateTime() {
+    @NonNull public String dateTimeOriginal() {
         return StringUtils.defaultString(dateTimeOriginal == null ? null : dateTimeOriginal.value());
+    }
+
+    @NonNull public String dateTime() {
+        return StringUtils.defaultString(dateTime == null ? null : dateTime.value());
     }
 
     @NonNull public String artist() {
         return StringUtils.defaultString(artist == null ? null : artist.value());
+    }
+
+    @NonNull
+    public String getCategories() {
+        return StringUtils.defaultString(categories == null ? null : categories.value());
+    }
+
+    @NonNull
+    public String getGpsLatitude() {
+        return StringUtils.defaultString(gpsLatitude == null ? null : gpsLatitude.value());
+    }
+
+    @NonNull
+    public String getGpsLongitude() {
+        return StringUtils.defaultString(gpsLongitude == null ? null : gpsLongitude.value());
     }
 
     @NonNull public String credit() {


### PR DESCRIPTION
@dbrant Some changes were done in the data-client library which made some of the properties unavailable for us. 

Commit: https://github.com/wikimedia/wikimedia-android-data-client/commit/2cae5f38e349710e05e11b06d5736195f359c563

It would be great if you could check if they can be added back. 
