### PR TITLE
add depicted item to mwQueryResult

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=0.0.23
+VERSION_NAME=0.0.24
 GROUP_ID=com.dmitrybrant
 ARTIFACT_ID=wikimedia-android-data-client
 GRADLE_BINTRAY_PLUGIN_VERSION=1.7.3

--- a/src/main/java/org/wikipedia/dataclient/mwapi/DepictedItem.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/DepictedItem.java
@@ -1,0 +1,22 @@
+package org.wikipedia.dataclient.mwapi;
+
+public class DepictedItem {
+
+    private String searchinfo;
+
+    private String search;
+
+    private String success;
+
+    public String getSearchinfo() {
+        return searchinfo;
+    }
+
+    public String getSearch() {
+        return search;
+    }
+
+    public String getSuccess() {
+        return success;
+    }
+}

--- a/src/main/java/org/wikipedia/dataclient/mwapi/GeoSearchItem.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/GeoSearchItem.java
@@ -1,19 +1,21 @@
 package org.wikipedia.dataclient.mwapi;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.apache.commons.lang3.StringUtils;
+
 @SuppressWarnings("unused")
 public class GeoSearchItem {
-
-    private String title;
+    @Nullable private String title;
     @SerializedName("lat") private double latitude;
     @SerializedName("lon") private double longitude;
     @SerializedName("dist") private double distance;
 
     @NonNull public String getTitle() {
-        return title;
+        return StringUtils.defaultString(title);
     }
 
     public double getLatitude() {

--- a/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
@@ -28,6 +28,7 @@ public class MwQueryResult extends BaseModel implements PostProcessingTypeAdapte
     @Nullable private List<ConvertedTitle> converted;
     @SerializedName("userinfo") private UserInfo userInfo;
     @Nullable private List<ListUserResponse> users;
+    @Nullable private DepictedItem depictedItem;
     @Nullable private Tokens tokens;
     @SerializedName("authmanagerinfo") @Nullable private MwAuthManagerInfo amInfo;
     @Nullable private MarkReadResponse echomarkread;
@@ -103,6 +104,10 @@ public class MwQueryResult extends BaseModel implements PostProcessingTypeAdapte
 
     @Nullable public List<RecentChange> getRecentChanges() {
         return recentchanges;
+    }
+
+    @Nullable public DepictedItem getDepictedItem() {
+        return depictedItem;
     }
 
     @Nullable public ListUserResponse getUserResponse(@NonNull String userName) {

--- a/src/main/java/org/wikipedia/gallery/GalleryItem.java
+++ b/src/main/java/org/wikipedia/gallery/GalleryItem.java
@@ -188,7 +188,7 @@ public class GalleryItem implements Serializable {
         }
     }
 
-    private static class StructuredData implements Serializable {
+    public static class StructuredData implements Serializable {
         @Nullable private HashMap<String, String> captions;
     }
 }


### PR DESCRIPTION
Commons app recently added a feature to search for depictions 

The MwQueryResult in the library doesn't contain DepictedItem object. This PR adds the model class.