### PR TITLE
Created MwQueryLogEvents class for logevents queries

### DIFF
--- a/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryLogEvent.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryLogEvent.java
@@ -73,6 +73,10 @@ public class MwQueryLogEvent extends BaseModel {
         return tags;
     }
 
+    public boolean isDeleted() {
+        return pageid==0;
+    }
+
     public Params params() {
         return params;
     }

--- a/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryLogEvent.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryLogEvent.java
@@ -1,7 +1,10 @@
 package org.wikipedia.dataclient.mwapi;
 
 import org.wikipedia.model.BaseModel;
+import org.wikipedia.util.DateUtil;
 
+import java.text.ParseException;
+import java.util.Date;
 import java.util.List;
 
 @SuppressWarnings("unused")
@@ -59,6 +62,14 @@ public class MwQueryLogEvent extends BaseModel {
 
     public String timestamp() {
         return timestamp;
+    }
+
+    public Date date(){
+        try {
+            return DateUtil.iso8601DateParse(timestamp);
+        } catch (ParseException e) {
+            return null;
+        }
     }
 
     public String comment() {

--- a/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryLogEvent.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryLogEvent.java
@@ -1,0 +1,92 @@
+package org.wikipedia.dataclient.mwapi;
+
+import org.wikipedia.model.BaseModel;
+
+import java.util.List;
+
+@SuppressWarnings("unused")
+public class MwQueryLogEvent extends BaseModel {
+    private int logid;
+    private int ns;
+    private int index;
+    private String title;
+    private int pageid;
+    private Params params;
+    private String type;
+    private String action;
+    private String user;
+    private int userid;
+    private String timestamp;
+    private String comment;
+    private String parsedcomment;
+    private List<String> tags;
+
+    public int logid() {
+        return logid;
+    }
+
+    public int ns() {
+        return ns;
+    }
+
+    public int index() {
+        return index;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public int pageid() {
+        return pageid;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public String action() {
+        return action;
+    }
+
+    public String user() {
+        return user;
+    }
+
+    public int userid() {
+        return userid;
+    }
+
+    public String timestamp() {
+        return timestamp;
+    }
+
+    public String comment() {
+        return comment;
+    }
+
+    public String parsedcomment() {
+        return parsedcomment;
+    }
+
+    public List<String> tags() {
+        return tags;
+    }
+
+    public Params params() {
+        return params;
+    }
+
+    public static class Params{
+        private String img_sha1;
+        private String img_timestamp;
+
+        public String img_sha1() {
+            return img_sha1;
+        }
+
+        public String img_timestamp() {
+            return img_timestamp;
+        }
+    }
+}

--- a/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/MwQueryResult.java
@@ -39,6 +39,8 @@ public class MwQueryResult extends BaseModel implements PostProcessingTypeAdapte
     @SerializedName("wikimediaeditortaskscounts") @Nullable private EditorTaskCounts editorTaskCounts;
     @SerializedName("allimages") @Nullable private List<ImageDetails> allImages;
     @SerializedName("geosearch") @Nullable private List<GeoSearchItem> geoSearch;
+    @Nullable private List<MwQueryLogEvent> logevents;
+
 
     @Nullable public List<MwQueryPage> pages() {
         return pages;
@@ -213,6 +215,11 @@ public class MwQueryResult extends BaseModel implements PostProcessingTypeAdapte
                 }
             }
         }
+    }
+
+    @Nullable
+    public List<MwQueryLogEvent> logevents() {
+        return logevents;
     }
 
     private static class Redirect {

--- a/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
+++ b/src/main/java/org/wikipedia/dataclient/mwapi/UserInfo.java
@@ -8,17 +8,30 @@ import java.util.Map;
 
 @SuppressWarnings("unused")
 public class UserInfo {
+    @NonNull
     private String name;
+    @NonNull
     private int id;
 
+    //Block information
+    private int blockid;
+    private String blockedby;
+    private int blockedbyid;
+    private String blockreason;
+    private String blocktimestamp;
+    private String blockexpiry;
+
     // Object type is any JSON type.
-    @Nullable private Map<String, ?> options;
+    @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+    @Nullable
+    private Map<String, ?> options;
 
     public int id() {
         return id;
     }
 
-    @NonNull public Map<String, String> userjsOptions() {
+    @NonNull
+    public Map<String, String> userjsOptions() {
         Map<String, String> map = new HashMap<>();
         if (options != null) {
             for (Map.Entry<String, ?> entry : options.entrySet()) {
@@ -29,5 +42,43 @@ public class UserInfo {
             }
         }
         return map;
+    }
+
+    @NonNull
+    public int blockid() {
+        return blockid;
+    }
+
+    @NonNull
+    public String blockedby() {
+        if (blockedby != null)
+            return blockedby;
+        else return "";
+    }
+
+    @NonNull
+    public int blockedbyid() {
+        return blockedbyid;
+    }
+
+    @NonNull
+    public String blockreason() {
+        if (blockreason != null)
+            return blockreason;
+        else return "";
+    }
+
+    @NonNull
+    public String blocktimestamp() {
+        if (blocktimestamp != null)
+            return blocktimestamp;
+        else return "";
+    }
+
+    @NonNull
+    public String blockexpiry() {
+        if (blockexpiry != null)
+            return blockexpiry;
+        else return "";
     }
 }


### PR DESCRIPTION
As a part of commons-app/apps-android-commons#3026 I need to run queries against the `logevents` list. This PR adds the MwQueryLogEvents class and relevant fields. [Example query](https://commons.wikimedia.org/w/api.php?action=query&format=json&list=logevents&leprop=title|timestamp|ids|type|user|userid|comment|parsedcomment|details|tags&leuser=Wilfredor&lelimit=10)