### PR TITLE
Send central auth cookies to domains that end in ".wikidata.org", ".wikimedia.org", and ".mediawiki.org" in addition to those that end in ".wikipedia.org"

### DIFF
--- a/src/main/java/org/wikipedia/dataclient/SharedPreferenceCookieManager.java
+++ b/src/main/java/org/wikipedia/dataclient/SharedPreferenceCookieManager.java
@@ -21,7 +21,7 @@ import okhttp3.HttpUrl;
 public final class SharedPreferenceCookieManager implements CookieJar {
     private static final String CENTRAL_AUTH_PREFIX = "centralauth_";
     private static final String WIKIPEDIA_DOMAIN = "wikipedia.org";
-    private static final String MEDIAWIKI_DOMAIN = "wikimedia.org";
+    private static final String MEDIAWIKI_DOMAIN = "mediawiki.org";
     private static final String WIKIDATA_DOMAIN = "wikidata.org";
     private static final String WIKIMEDIA_DOMAIN = "wikimedia.org";
     private static final List<String> CENTRAL_AUTH_DOMAINS = new ArrayList<String>(){{


### PR DESCRIPTION
- Updated to read central auth cookies from any authenticated central auth domain
- Only send central auth cookies to central auth domains
- Fixed a bug where a domain like `anythingherewikipedia.org` would be recognized as a central auth domain